### PR TITLE
Update

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ env:
 
 
 before_install:
+    # Remove homebrew.
     - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
 
 install:
     - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,21 @@ env:
     - secure: "jQ2W+EVuv34VW6tQKHiIs8Zl1LRqXeEQGbq+kSfXtrDHBZA6PEg8GB0VOZsT50yM+nLqnaLcBCCGd58R54C1eyZ0OcrZZXNg+qbMM9z0TvfyVxQnkTzdDpfN8CHPtX9GXBo8TAYD3mLbAHq1FajJl/7o1YrInPTcu173IBIKEfBHHfoyTho3Ta9j9vkmS/ecXWbsy9MqxfaFnRkAFx8ha9DZ9UVYto3Xyzua/VwYRY+FoBiNEbh8g70U8+XUAKKs7kL3oJyQclHxT0WNBXqTVjq57DesFeIsGD7zQd3tVCxm3ow4wc2pgmBoWEuPRRAKisbGn1EL44NtEO+UPQyi2luj2T8GDNO5522V4FfYLd2+Ftgwzu2kUXgX+xLfMOAGYcHnB4KmPfkgPoK3bC8hI+Xqm4Rs++gfsGvk5miOXKl19Jpci3XOGmZYnJuqtbmjNFVD/b5V7uTnch0Tl2DO8en6xn3pHkP3IgV7CD0FfkaMHtLtJv+9hhR1ljvomtnrQrpqKJxvkDYcBNE/+xq1kLUwTHakhbXveZ78itoG0ofi2sBBOWjbOM8lOcUhUqas/+NZmDGDxiCMM0NohSU/C78Mjjao+fQuDyAt01jMaI9G90LqlKWN0WylhU2e+3bsFAKQ98LLmzgbWqEOmOIYi4RRfkNFVJ7dN+oxY30PPsU="
 
 
+before_install:
+    - brew remove --force $(brew list)
+
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ About django
 
 Home: http://www.djangoproject.com/
 
-Package license: BSD License
+Package license: BSD 3-Clause
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1

--- a/recipe/libgeos.patch
+++ b/recipe/libgeos.patch
@@ -1,6 +1,6 @@
---- django/contrib/gis/geos/libgeos.py	2016-03-05 11:33:15.000000000 -0300
-+++ django/contrib/gis/geos/libgeos.py	2016-03-11 18:54:05.282979648 -0300
-@@ -8,57 +8,35 @@
+--- django/contrib/gis/geos/libgeos.py	2016-04-01 14:33:55.000000000 -0300
++++ django/contrib/gis/geos/libgeos.py	2016-04-27 16:06:08.566710862 -0300
+@@ -8,9 +8,9 @@
  """
  import logging
  import os
@@ -11,67 +11,68 @@
  
  from django.contrib.gis.geos.error import GEOSException
  from django.core.exceptions import ImproperlyConfigured
+@@ -20,47 +20,27 @@
  
- logger = logging.getLogger('django.contrib.gis')
  
--# Custom library path set?
--try:
--    from django.conf import settings
--    lib_path = settings.GEOS_LIBRARY_PATH
--except (AttributeError, EnvironmentError,
--        ImportError, ImproperlyConfigured):
--    lib_path = None
+ def load_geos():
+-    # Custom library path set?
+-    try:
+-        from django.conf import settings
+-        lib_path = settings.GEOS_LIBRARY_PATH
+-    except (AttributeError, EnvironmentError,
+-            ImportError, ImproperlyConfigured):
+-        lib_path = None
 -
--# Setting the appropriate names for the GEOS-C library.
--if lib_path:
--    lib_names = None
--elif os.name == 'nt':
--    # Windows NT libraries
--    lib_names = ['geos_c', 'libgeos_c-1']
--elif os.name == 'posix':
--    # *NIX libraries
--    lib_names = ['geos_c', 'GEOS']
--else:
--    raise ImportError('Unsupported OS "%s"' % os.name)
+-    # Setting the appropriate names for the GEOS-C library.
+-    if lib_path:
+-        lib_names = None
+-    elif os.name == 'nt':
+-        # Windows NT libraries
+-        lib_names = ['geos_c', 'libgeos_c-1']
+-    elif os.name == 'posix':
+-        # *NIX libraries
+-        lib_names = ['geos_c', 'GEOS']
+-    else:
+-        raise ImportError('Unsupported OS "%s"' % os.name)
 -
--# Using the ctypes `find_library` utility to find the path to the GEOS
--# shared library.  This is better than manually specifying each library name
--# and extension (e.g., libgeos_c.[so|so.1|dylib].).
--if lib_names:
--    for lib_name in lib_names:
--        lib_path = find_library(lib_name)
--        if lib_path is not None:
--            break
+-    # Using the ctypes `find_library` utility to find the path to the GEOS
+-    # shared library.  This is better than manually specifying each library name
+-    # and extension (e.g., libgeos_c.[so|so.1|dylib].).
+-    if lib_names:
+-        for lib_name in lib_names:
+-            lib_path = find_library(lib_name)
+-            if lib_path is not None:
+-                break
 -
--# No GEOS library could be found.
--if lib_path is None:
--    raise ImportError(
--        'Could not find the GEOS library (tried "%s"). '
--        'Try setting GEOS_LIBRARY_PATH in your settings.' %
--        '", "'.join(lib_names)
--    )
--
- # Getting the GEOS C library.  The C interface (CDLL) is used for
- # both *NIX and Windows.
- # See the GEOS C API source code for more details on the library function calls:
- #  http://geos.refractions.net/ro/doxygen_docs/html/geos__c_8h-source.html
--lgeos = CDLL(lib_path)
-+if os.name == 'posix':
-+    platform = os.uname()[0]
-+    if platform == 'Linux':
-+        libname = 'libgeos_c.so'
-+    elif platform == 'Darwin':
-+        libname = 'libgeos_c.dylib'
-+    lgeos = CDLL(os.path.join(sys.prefix, 'lib', libname))
-+elif os.name == 'nt':
-+    # On Windows, the GDAL binaries have some OSR routines exported with
-+    # STDCALL, while others are not.  Thus, the library will also need to
-+    # be loaded up as WinDLL for said OSR functions that require the
-+    # different calling convention.
-+    libname = os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll')
-+    lgeos = CDLL(libname)
-+else:
-+    raise Exception('No valid platform name. Found {}'.format(os.name))
- 
- # The notice and error handler C function callback definitions.
- # Supposed to mimic the GEOS message handler (C below):
+-    # No GEOS library could be found.
+-    if lib_path is None:
+-        raise ImportError(
+-            'Could not find the GEOS library (tried "%s"). '
+-            'Try setting GEOS_LIBRARY_PATH in your settings.' %
+-            '", "'.join(lib_names)
+-        )
+     # Getting the GEOS C library.  The C interface (CDLL) is used for
+     # both *NIX and Windows.
+     # See the GEOS C API source code for more details on the library function calls:
+     #  http://geos.refractions.net/ro/doxygen_docs/html/geos__c_8h-source.html
+-    _lgeos = CDLL(lib_path)
++    if os.name == 'posix':
++        platform = os.uname()[0]
++        if platform == 'Linux':
++            libname = 'libgeos_c.so'
++        elif platform == 'Darwin':
++            libname = 'libgeos_c.dylib'
++        _lgeos = CDLL(os.path.join(sys.prefix, 'lib', libname))
++    elif os.name == 'nt':
++        # On Windows, the GDAL binaries have some OSR routines exported with
++        # STDCALL, while others are not.  Thus, the library will also need to
++        # be loaded up as WinDLL for said OSR functions that require the
++        # different calling convention.
++        libname = os.path.join(sys.prefix, 'Library', 'bin', 'geos_c.dll')
++        _lgeos = CDLL(libname)
++    else:
++        raise Exception('No valid platform name. Found {}'.format(os.name))
++
+     # Here we set up the prototypes for the initGEOS_r and finishGEOS_r
+     # routines.  These functions aren't actually called until they are
+     # attached to a GEOS context handle -- this actually occurs in

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.9.5" %}
+{% set version = "1.9.6" %}
 
 package:
     name: django
@@ -6,8 +6,8 @@ package:
 
 source:
     fn: Django-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/D/Django/Django-{{ version }}.tar.gz
-    md5: 419835cef8d42a1a0a3fd6e1eaa24475
+    url: https://pypi.io/packages/source/D/Django/Django-{{ version }}.tar.gz
+    md5: 07d9b3883198caa847b917c94b665452
     patches:
         # Hard-code gdal and geos' paths to the corresponding conda packages.
         - libgdal.patch
@@ -34,7 +34,7 @@ test:
         - django
         - django.apps
         - django.conf
-        - django.conf.app_template.migrations
+        - django.conf.app_template.migrations  # [not py27]
         - django.conf.locale
         - django.conf.locale.ar
         - django.conf.locale.az

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.11" %}
+{% set version = "1.9.5" %}
 
 package:
     name: django
@@ -7,7 +7,7 @@ package:
 source:
     fn: Django-{{ version }}.tar.gz
     url: https://pypi.python.org/packages/source/D/Django/Django-{{ version }}.tar.gz
-    md5: 1c85d0d582dc211adc6851dd2dc86228
+    md5: 419835cef8d42a1a0a3fd6e1eaa24475
     patches:
         # Hard-code gdal and geos' paths to the corresponding conda packages.
         - libgdal.patch
@@ -102,10 +102,8 @@ test:
         - django.conf.locale.tr
         - django.conf.locale.uk
         - django.conf.locale.vi
-        - django.conf.locale.zh_CN
         - django.conf.locale.zh_Hans
         - django.conf.locale.zh_Hant
-        - django.conf.locale.zh_TW
         - django.conf.urls
         - django.contrib
         #- django.contrib.admin
@@ -226,9 +224,10 @@ test:
 
 about:
     home: http://www.djangoproject.com/
-    license: BSD License
+    license: BSD 3-Clause
     summary: A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
 
 extra:
     recipe-maintainers:
         - kwilcox
+        - ocefpaf


### PR DESCRIPTION
```
==========================
Django 1.9.6 release notes
==========================

*May 2, 2016*

Django 1.9.6 fixes several bugs in 1.9.5.

Bugfixes
========

* Added support for relative path redirects to the test client and to
  ``SimpleTestCase.assertRedirects()`` because Django 1.9 no longer converts
  redirects to absolute URIs (:ticket:`26428`).

* Fixed ``TimeField`` microseconds round-tripping on MySQL and SQLite
  (:ticket:`26498`).

* Prevented ``makemigrations`` from generating infinite migrations for a model
  field that references a ``functools.partial`` (:ticket:`26475`).

* Fixed a regression where ``SessionBase.pop()`` returned ``None`` rather than
  raising a ``KeyError`` for nonexistent values (:ticket:`26520`).

* Fixed a regression causing the cached template loader to crash when using
  template names starting with a dash (:ticket:`26536`).

* Restored conversion of an empty string to null when saving values of
  ``GenericIPAddressField`` on SQLite and MySQL (:ticket:`26557`).

* Fixed a ``makemessages`` regression where temporary ``.py`` extensions were
  leaked in source file paths (:ticket:`26341`).

Django 1.9.5 fixes several bugs in 1.9.4.

Bugfixes
========

* Made ``MultiPartParser`` ignore filenames that normalize to an empty string
  to fix crash in ``MemoryFileUploadHandler`` on specially crafted user input
  (:ticket:`26325`).

* Fixed a race condition in ``BaseCache.get_or_set()`` (:ticket:`26332`). It
  now returns the ``default`` value instead of ``False`` if there's an error
  when trying to add the value to the cache.

* Fixed data loss on SQLite where ``DurationField`` values with fractional
  seconds could be saved as ``None`` (:ticket:`26324`).

* The forms in ``contrib.auth`` no longer strip trailing and leading whitespace
  from the password fields (:ticket:`26334`). The change requires users who set
  their password to something with such whitespace after a site updated to
  Django 1.9 to reset their password. It provides backwards-compatibility for
  earlier versions of Django.

* Fixed a memory leak in the cached template loader (:ticket:`26306`).

* Fixed a regression that caused ``collectstatic --clear`` to fail if the
  storage doesn't implement ``path()`` (:ticket:`26297`).

* Fixed a crash when using a reverse lookup with a subquery when a
  ``ForeignKey`` has a ``to_field`` set to something other than the primary key
  (:ticket:`26373`).

* Fixed a regression in ``CommonMiddleware`` that caused spurious warnings in
  logs on requests missing a trailing slash (:ticket:`26293`).

* Restored the functionality of the admin's ``raw_id_fields`` in
  ``list_editable`` (:ticket:`26387`).

* Fixed a regression with abstract model inheritance and explicit parent links
  (:ticket:`26413`).

* Fixed a migrations crash on SQLite when renaming the primary key of a model
  containing a ``ForeignKey`` to ``'self'`` (:ticket:`26384`).

* Fixed ``JSONField`` inadvertently escaping its contents when displaying values
  after failed form validation (:ticket:`25532`).
```