### PR TITLE
Update to 1.8.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,24 @@ env:
     - secure: "jQ2W+EVuv34VW6tQKHiIs8Zl1LRqXeEQGbq+kSfXtrDHBZA6PEg8GB0VOZsT50yM+nLqnaLcBCCGd58R54C1eyZ0OcrZZXNg+qbMM9z0TvfyVxQnkTzdDpfN8CHPtX9GXBo8TAYD3mLbAHq1FajJl/7o1YrInPTcu173IBIKEfBHHfoyTho3Ta9j9vkmS/ecXWbsy9MqxfaFnRkAFx8ha9DZ9UVYto3Xyzua/VwYRY+FoBiNEbh8g70U8+XUAKKs7kL3oJyQclHxT0WNBXqTVjq57DesFeIsGD7zQd3tVCxm3ow4wc2pgmBoWEuPRRAKisbGn1EL44NtEO+UPQyi2luj2T8GDNO5522V4FfYLd2+Ftgwzu2kUXgX+xLfMOAGYcHnB4KmPfkgPoK3bC8hI+Xqm4Rs++gfsGvk5miOXKl19Jpci3XOGmZYnJuqtbmjNFVD/b5V7uTnch0Tl2DO8en6xn3pHkP3IgV7CD0FfkaMHtLtJv+9hhR1ljvomtnrQrpqKJxvkDYcBNE/+xq1kLUwTHakhbXveZ78itoG0ofi2sBBOWjbOM8lOcUhUqas/+NZmDGDxiCMM0NohSU/C78Mjjao+fQuDyAt01jMaI9G90LqlKWN0WylhU2e+3bsFAKQ98LLmzgbWqEOmOIYi4RRfkNFVJ7dN+oxY30PPsU="
 
 
+before_install:
+    # Remove homebrew.
+    - brew remove --force $(brew list)
+    - brew cleanup -s
+    - rm -rf $(brew --cache)
+
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: http://www.djangoproject.com/
 
 Package license: BSD License
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.8.11" %}
+{% set version = "1.8.13" %}
 
 package:
     name: django
@@ -6,8 +6,8 @@ package:
 
 source:
     fn: Django-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/D/Django/Django-{{ version }}.tar.gz
-    md5: 1c85d0d582dc211adc6851dd2dc86228
+    url: https://pypi.io/packages/source/D/Django/Django-{{ version }}.tar.gz
+    md5: a77e1ba9991f762de20bf03de57e39eb
     patches:
         # Hard-code gdal and geos' paths to the corresponding conda packages.
         - libgdal.patch


### PR DESCRIPTION
Creating a maintaince branch for the `1.8.x` series and updating to 1.8.13

Ping @kwilcox 

```
Django 1.8.13 release notes
===========================

*May 2, 2016*

Django 1.8.13 fixes several bugs in 1.8.12.

Bugfixes
========

* Fixed ``TimeField`` microseconds round-tripping on MySQL and SQLite
  (:ticket:`26498`).

* Restored conversion of an empty string to null when saving values of
  ``GenericIPAddressField`` on SQLite and MySQL (:ticket:`26557`).
```