### PR TITLE
Fix win-64 build issue for django version 1.7.11

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,4 +16,4 @@ del %DOC_EPUB_BASE%\docicons-warning.png
 copy %DOC_BASE%\docicons-warning.png %DOC_EPUB_BASE%\docicons-warning.png
 
 :: now do the normal setup ...
-%PYTHON% -m pip install . --no-deps -vv"  # [not win]
+%PYTHON% -m pip install . --no-deps -vv

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,0 +1,19 @@
+:: set required base paths 
+SET DOC_BASE=%SRC_DIR%\docs\_theme\djangodocs\static
+SET DOC_EPUB_BASE=%SRC_DIR%\docs\_theme\djangodocs-epub\static
+
+:: symbolic links in the djangodocs-epub/static folder for some reason
+:: become dangling without valid target when extracting the archive, failing
+:: the build during copying the files. So, in order to build, we
+:: simply replace the dangling links with their actual target files ... 
+del %DOC_EPUB_BASE%\docicons-behindscenes.png
+copy %DOC_BASE%\docicons-behindscenes.png %DOC_EPUB_BASE%\docicons-behindscenes.png
+del %DOC_EPUB_BASE%\docicons-note.png
+copy %DOC_BASE%\docicons-note.png %DOC_EPUB_BASE%\docicons-note.png
+del %DOC_EPUB_BASE%\docicons-philosophy.png
+copy %DOC_BASE%\docicons-philosophy.png %DOC_EPUB_BASE%\docicons-philosophy.png
+del %DOC_EPUB_BASE%\docicons-warning.png
+copy %DOC_BASE%\docicons-warning.png %DOC_EPUB_BASE%\docicons-warning.png
+
+:: now do the normal setup ...
+"%PYTHON%" -m pip install --no-deps --ignore-installed .

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -16,4 +16,4 @@ del %DOC_EPUB_BASE%\docicons-warning.png
 copy %DOC_BASE%\docicons-warning.png %DOC_EPUB_BASE%\docicons-warning.png
 
 :: now do the normal setup ...
-"%PYTHON%" -m pip install --no-deps --ignore-installed .
+%PYTHON% -m pip install . --no-deps -vv"  # [not win]

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+$PYTHON -m pip install --no-deps --ignore-installed -vvv .
+

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-$PYTHON -m pip install --no-deps --ignore-installed -vvv .

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -1,4 +1,3 @@
 #!/bin/bash
 
 $PYTHON -m pip install --no-deps --ignore-installed -vvv .
-

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,6 +7,7 @@ package:
 source:
   url: https://pypi.io/packages/source/D/Django/Django-{{ version }}.tar.gz
   sha256: 2039144fce8f1b603d03fa5a5643578df1ad007c4ed41a617f02a3943f7059a1
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"  # [not win]
   patches:
     # Hard-code gdal and geos' paths to the corresponding conda packages.
     - libgdal.patch

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,14 +14,14 @@ source:
     - geos-ver.patch
 
 build:
-  number: 1000
+  number: 1
   # do only python2.7 due to HTMLParseError removed in python>=3.5
   skip: True  # [py3k]
   entry_points:
     - django-admin = django.core.management:execute_from_command_line
 
 requirements:
-  build:
+  host:
     - python
     - pip
   run:
@@ -29,7 +29,6 @@ requirements:
 
 test:
   requires:
-    - gdal 2.2.*
     - pytz
   imports:
     - django
@@ -111,23 +110,6 @@ test:
     - django.contrib.flatpages
     - django.contrib.flatpages.migrations
     - django.contrib.flatpages.templatetags
-    - django.contrib.gis
-    - django.contrib.gis.db
-    - django.contrib.gis.db.backends
-    - django.contrib.gis.db.backends.base
-    - django.contrib.gis.db.backends.mysql
-    - django.contrib.gis.db.backends.oracle
-    - django.contrib.gis.db.backends.postgis
-    - django.contrib.gis.db.backends.spatialite
-    - django.contrib.gis.forms
-    - django.contrib.gis.gdal
-    - django.contrib.gis.gdal.prototypes
-    - django.contrib.gis.geometry
-    - django.contrib.gis.geos
-    - django.contrib.gis.geos.prototypes
-    - django.contrib.gis.management
-    - django.contrib.gis.management.commands
-    - django.contrib.gis.utils
     - django.contrib.humanize
     - django.contrib.humanize.templatetags
     - django.contrib.messages
@@ -191,7 +173,7 @@ test:
 
 about:
   home: http://www.djangoproject.com/
-  license: BSD 3-Clause
+  license: BSD-3-Clause
   license_file: LICENSE
   summary: 'A high-level Python Web framework that encourages rapid development and clean, pragmatic design.'
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
     - geos-ver.patch
 
 build:
-  number: 0
+  number: 1000
   # do only python2.7 due to HTMLParseError removed in python>=3.5
   skip: True  # [py3k]
   entry_points:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,7 +17,6 @@ build:
   number: 0
   # do only python2.7 due to HTMLParseError removed in python>=3.5
   skip: True  # [py3k]
-  script: python -m pip install --no-deps --ignore-installed -vvv .
   entry_points:
     - django-admin = django.core.management:execute_from_command_line
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,6 @@ package:
 source:
   url: https://pypi.io/packages/source/D/Django/Django-{{ version }}.tar.gz
   sha256: 2039144fce8f1b603d03fa5a5643578df1ad007c4ed41a617f02a3943f7059a1
-  script: "{{ PYTHON }} -m pip install . --no-deps -vv"  # [not win]
   patches:
     # Hard-code gdal and geos' paths to the corresponding conda packages.
     - libgdal.patch
@@ -16,6 +15,7 @@ source:
 
 build:
   number: 1
+  script: "{{ PYTHON }} -m pip install . --no-deps -vv"  # [not win]
   # do only python2.7 due to HTMLParseError removed in python>=3.5
   skip: True  # [py3k]
   entry_points:


### PR DESCRIPTION
Hi @ocefpaf I finally found some time to fix the build issue with win-64, hopefully it will build now (ping @ltalirz)

Checklist
* [X] Used a fork of the feedstock to propose changes
* [X] Bumped the build number (if the version is unchanged)
* [X] Ensured the license file is being packaged.
