### PR TITLE
Fix recipe

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -12,7 +12,6 @@ jobs:
         CONFIG: linux_64_
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: condaforge/linux-anvil-comp7
-    maxParallel: 8
   timeoutInMinutes: 360
 
   steps:

--- a/.scripts/run_docker_build.sh
+++ b/.scripts/run_docker_build.sh
@@ -74,6 +74,8 @@ docker run ${DOCKER_RUN_ARGS} \
            -e CI \
            -e FEEDSTOCK_NAME \
            -e CPU_COUNT \
+           -e BUILD_WITH_CONDA_DEBUG \
+           -e BUILD_OUTPUT_ID \
            -e BINSTAR_TOKEN \
            -e FEEDSTOCK_TOKEN \
            -e STAGING_BINSTAR_TOKEN \

--- a/README.md
+++ b/README.md
@@ -5,11 +5,13 @@ Home: http://www.djangoproject.com/
 
 Package license: BSD-3-Clause
 
-Feedstock license: BSD-3-Clause
+Feedstock license: [BSD-3-Clause](https://github.com/conda-forge/django-feedstock/blob/master/LICENSE.txt)
 
 Summary: A high-level Python Web framework that encourages rapid development and clean, pragmatic design.
 
+Development: https://github.com/django/django
 
+Documentation: http://www.djangoproject.com/
 
 Current build status
 ====================

--- a/build-locally.py
+++ b/build-locally.py
@@ -12,6 +12,10 @@ from argparse import ArgumentParser
 def setup_environment(ns):
     os.environ["CONFIG"] = ns.config
     os.environ["UPLOAD_PACKAGES"] = "False"
+    if ns.debug:
+        os.environ["BUILD_WITH_CONDA_DEBUG"] = "1"
+        if ns.output_id:
+            os.environ["BUILD_OUTPUT_ID"] = ns.output_id
 
 
 def run_docker_build(ns):
@@ -51,6 +55,14 @@ def verify_config(ns):
 def main(args=None):
     p = ArgumentParser("build-locally")
     p.add_argument("config", default=None, nargs="?")
+    p.add_argument(
+        "--debug",
+        action="store_true",
+        help="Setup debug environment using `conda debug`",
+    )
+    p.add_argument(
+        "--output-id", help="If running debug, specify the output to setup."
+    )
 
     ns = p.parse_args(args=args)
     verify_config(ns)

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: a2127ad0150ec6966655bedf15dbbff9697cc86d61653db2da1afa506c0b04cc
 
 build:
-  number: 0
+  number: 1
   noarch: python
   script: {{ PYTHON }} -m pip install . -vv
   entry_points:
@@ -21,9 +21,9 @@ requirements:
     - pip
   run:
     - python >=3.6
+    - asgiref >=3.2.10,<3.3
     - pytz
     - sqlparse >=0.2.2
-    - asgiref >=3.2,<4
 
 test:
   requires:


### PR DESCRIPTION
There is no need to remove the previous build number. The pin is overly strict upstream This one is mostly to avoid `pip check` failures.