### PR TITLE
Add LTS v4.2.11 to conda-forge - 2 CVE fixes over 4.2.8, merge to 4.2.x

### DIFF
--- a/.azure-pipelines/azure-pipelines-linux.yml
+++ b/.azure-pipelines/azure-pipelines-linux.yml
@@ -13,6 +13,7 @@ jobs:
         UPLOAD_PACKAGES: 'True'
         DOCKER_IMAGE: quay.io/condaforge/linux-anvil-cos7-x86_64
   timeoutInMinutes: 360
+  variables: {}
 
   steps:
   # configure qemu binfmt-misc running.  This allows us to run docker containers

--- a/.scripts/build_steps.sh
+++ b/.scripts/build_steps.sh
@@ -65,7 +65,7 @@ if [[ "${BUILD_WITH_CONDA_DEBUG:-0}" == 1 ]]; then
     # Drop into an interactive shell
     /bin/bash
 else
-    conda build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
+    conda-build "${RECIPE_ROOT}" -m "${CI_SUPPORT}/${CONFIG}.yaml" \
         --suppress-variables ${EXTRA_CB_OPTIONS:-} \
         --clobber-file "${CI_SUPPORT}/clobber_${CONFIG}.yaml" \
         --extra-meta flow_run_id="${flow_run_id:-}" remote_url="${remote_url:-}" sha="${sha:-}"

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "5.0.3" %}
+{% set version = "4.2.11" %}
 
 package:
   name: django
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/D/Django/Django-{{ version }}.tar.gz
-  sha256: 5fb37580dcf4a262f9258c1f4373819aacca906431f505e4688e37f3a99195df
+  sha256: 6e6ff3db2d8dd0c986b4eec8554c8e4f919b5c1ff62a5b4390c17aff2ed6e5c4
 
 build:
   number: 0
@@ -21,11 +21,14 @@ build:
 
 requirements:
   host:
-    - python >=3.10
+    - python >=3.8
     - pip
   run:
-    - python >=3.10
-    - asgiref >=3.7.0,<4
+    - python >=3.8
+    - asgiref >=3.6.0,<4
+    # Needs backports.zoneinfo only for py<39, but
+    # backports.zoneinfo conda package is empty for py>=39
+    - backports.zoneinfo
     - sqlparse >=0.3.1
 
 test:
@@ -149,6 +152,8 @@ test:
     - django.contrib.sessions.management.commands
     - django.contrib.sessions.migrations
     - django.contrib.sitemaps
+    - django.contrib.sitemaps.management
+    - django.contrib.sitemaps.management.commands
     - django.contrib.sites
     - django.contrib.sites.migrations
     - django.contrib.staticfiles


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->
Can we create a 4.2.x
Django LTS is currently version 4.2.X , this latest version fixes 2 CVE's
CVE-2024-27351
CVE-2024-24680

<!--
Please add any other relevant info below:
-->
https://www.djangoproject.com/download/#supported-versions
https://docs.djangoproject.com/en/5.0/releases/4.2.11/
https://docs.djangoproject.com/en/5.0/releases/4.2.10/
https://docs.djangoproject.com/en/5.0/releases/4.2.9/
