### PR TITLE
 Add LTS v4.2.16 to conda-forge and resolve CVEs

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "4.2.15" %}
+{% set version = "4.2.16" %}
 
 package:
   name: django
@@ -6,7 +6,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/D/Django/Django-{{ version }}.tar.gz
-  sha256: c77f926b81129493961e19c0e02188f8d07c112a1162df69bfab178ae447f94a
+  sha256: 6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad
 
 build:
   number: 0


### PR DESCRIPTION
Fixed CVE-2024-45231 -- Avoided server error on password reset when email sending fails. Fixed CVE-2024-45230 -- Mitigated potential DoS in urlize and urlizetrunc template filters.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
