### PR TITLE
Add 5.x and 4.x to `abi_migration_branches`

### DIFF
--- a/conda-forge.yml
+++ b/conda-forge.yml
@@ -1,5 +1,8 @@
 bot:
   inspection: update-grayskull
+  abi_migration_branches:
+    - "5.x"
+    - "4.x"
 provider: {linux_aarch64: default, linux_ppc64le: default, win: azure}
 conda_forge_output_validation: true
 github:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Add the LTS release branches to `abi_migration_branches` to ensure that they are picked up by the bots.